### PR TITLE
disable navbar and concertlog on dashboard page

### DIFF
--- a/src/Top.tsx
+++ b/src/Top.tsx
@@ -22,20 +22,18 @@ import Dashboard from "./pages/Dashboard";
 // This component contains state that is handled across different pages
 // This naming is what you get when an RTL engineer learns frontend lol
 const Top = () => {
-
   const location = useLocation();
   const currentPage = location.pathname.split("/")[1];
 
   // Component Control
-  const disableConcertLogger = (currentPage === "dashboard");
-  const disableNavbar = (currentPage === "dashboard");
+  const disableConcertLogger = currentPage === "dashboard";
+  const disableNavbar = currentPage === "dashboard";
 
   /*** Concert Logger ************************************/
   // State variables
   const [logOpen, setLogOpen] = useState(false);
   const [logEditMode, setLogEditMode] = useState(false);
   const [logEditID, setLogEditID] = useState<number | null>(null);
-
 
   // Callback functions
   const logButtonClickHandler: React.MouseEventHandler = () => {
@@ -132,12 +130,10 @@ const Top = () => {
       {" "}
       {/* A Container box to make body scroll sideways */}
       <SiteHeader />
-      { !disableNavbar &&
-      <NavBar {...navBarProps} />
-      }
+      {!disableNavbar && <NavBar {...navBarProps} />}
       {/* Div to push everything else down because header is fixed positioning */}
       {/* There must be a way to make it cleaner but this hacky thing works for now */}
-      <div style={{ height: (!disableNavbar) ? 224 : 96 }} />
+      <div style={{ height: !disableNavbar ? 224 : 96 }} />
       <Routes>
         <Route path="/" element={<Home {...homePageProps} />} />
         <Route path="/CMs/:initials" element={<CM logEdit={handleLogEdit} />} />
@@ -148,66 +144,70 @@ const Top = () => {
         />
         <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
-      {/* The Button to slide the Concert Log in and out*/
-      (!disableConcertLogger) &&
-      <Box
-        sx={{
-          overflow: "hidden", // This makes button box-shadow not appear outside of box
-          position: "fixed",
-          left: posleft,
-          top: 122,
-          zIndex: theme.zIndex.drawer + 1,
-          transform: "rotate(90deg)",
-          transformOrigin: `${buttonMargin}px ${buttonMargin + buttonHeight}px`,
-          // copied from Drawer Paper on DOM
-          // For some reason, I don't think it's perfectly aligned but pretty close.
-          //Maybe should change it all into a Slider component instead of Drawer in a subsequent commit?
-          transition: logOpen
-            ? "left 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms"
-            : "left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms",
-        }}
-      >
-        <Button
-          disableRipple
-          onClick={logButtonClickHandler}
-          variant="contained"
-          sx={{
-            boxShadow: 2,
-            height: buttonHeight,
-            position: "relative",
-            left: 0,
-            zIndex: theme.zIndex.drawer + 1,
-            backgroundColor: "primary.light",
-            color: "primary.dark",
-            textTransform: "none",
-            lineHeight: "18px",
-            mx: `${buttonMargin}px`,
-            mt: `${buttonMargin}px`,
-            borderRadius: "4px 4px 0px 0px",
-            "&.MuiButton-root": {
-              padding: "8px 12px", // not sure why this works but doing it in the sx prop doesn't
-              ":hover": {
-                backgroundColor: "primary.light",
-                fontWeight: "bold",
+      {
+        /* The Button to slide the Concert Log in and out*/
+        !disableConcertLogger && (
+          <Box
+            sx={{
+              overflow: "hidden", // This makes button box-shadow not appear outside of box
+              position: "fixed",
+              left: posleft,
+              top: 122,
+              zIndex: theme.zIndex.drawer + 1,
+              transform: "rotate(90deg)",
+              transformOrigin: `${buttonMargin}px ${
+                buttonMargin + buttonHeight
+              }px`,
+              // copied from Drawer Paper on DOM
+              // For some reason, I don't think it's perfectly aligned but pretty close.
+              //Maybe should change it all into a Slider component instead of Drawer in a subsequent commit?
+              transition: logOpen
+                ? "left 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms"
+                : "left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms",
+            }}
+          >
+            <Button
+              disableRipple
+              onClick={logButtonClickHandler}
+              variant="contained"
+              sx={{
                 boxShadow: 2,
-                //  "0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%)",
-              },
-            },
-          }}
-        >
-          Log
-        </Button>
-      </Box>
+                height: buttonHeight,
+                position: "relative",
+                left: 0,
+                zIndex: theme.zIndex.drawer + 1,
+                backgroundColor: "primary.light",
+                color: "primary.dark",
+                textTransform: "none",
+                lineHeight: "18px",
+                mx: `${buttonMargin}px`,
+                mt: `${buttonMargin}px`,
+                borderRadius: "4px 4px 0px 0px",
+                "&.MuiButton-root": {
+                  padding: "8px 12px", // not sure why this works but doing it in the sx prop doesn't
+                  ":hover": {
+                    backgroundColor: "primary.light",
+                    fontWeight: "bold",
+                    boxShadow: 2,
+                    //  "0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%)",
+                  },
+                },
+              }}
+            >
+              Log
+            </Button>
+          </Box>
+        )
       }
-      { !disableConcertLogger &&
-      <ConcertLogger
-        open={logOpen}
-        isEditMode={logEditMode}
-        editID={logEditID}
-        setEditMode={setLogEditMode}
-        cancelEdit={cancelEdit}
-      />
-      }
+      {!disableConcertLogger && (
+        <ConcertLogger
+          open={logOpen}
+          isEditMode={logEditMode}
+          editID={logEditID}
+          setEditMode={setLogEditMode}
+          cancelEdit={cancelEdit}
+        />
+      )}
     </Box> // Container
   );
 };

--- a/src/Top.tsx
+++ b/src/Top.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import NavBar from "./components/NavBar";
 import SiteHeader from "./components/SiteHeader";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 
 import CM from "./pages/CM";
 import Home from "./pages/Home";
@@ -22,11 +22,20 @@ import Dashboard from "./pages/Dashboard";
 // This component contains state that is handled across different pages
 // This naming is what you get when an RTL engineer learns frontend lol
 const Top = () => {
+
+  const location = useLocation();
+  const currentPage = location.pathname.split("/")[1];
+
+  // Component Control
+  const disableConcertLogger = (currentPage === "dashboard");
+  const disableNavbar = (currentPage === "dashboard");
+
   /*** Concert Logger ************************************/
   // State variables
   const [logOpen, setLogOpen] = useState(false);
   const [logEditMode, setLogEditMode] = useState(false);
   const [logEditID, setLogEditID] = useState<number | null>(null);
+
 
   // Callback functions
   const logButtonClickHandler: React.MouseEventHandler = () => {
@@ -49,6 +58,7 @@ const Top = () => {
   };
 
   /*** Log Tab Button ************************************/
+
   // Style and position variables
   const buttonHeight = 34;
   const buttonMargin = 4;
@@ -122,10 +132,12 @@ const Top = () => {
       {" "}
       {/* A Container box to make body scroll sideways */}
       <SiteHeader />
+      { !disableNavbar &&
       <NavBar {...navBarProps} />
+      }
       {/* Div to push everything else down because header is fixed positioning */}
       {/* There must be a way to make it cleaner but this hacky thing works for now */}
-      <div style={{ height: 224 }} />
+      <div style={{ height: (!disableNavbar) ? 224 : 96 }} />
       <Routes>
         <Route path="/" element={<Home {...homePageProps} />} />
         <Route path="/CMs/:initials" element={<CM logEdit={handleLogEdit} />} />
@@ -136,7 +148,8 @@ const Top = () => {
         />
         <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
-      {/* The Button to slide the Concert Log in and out*/}
+      {/* The Button to slide the Concert Log in and out*/
+      (!disableConcertLogger) &&
       <Box
         sx={{
           overflow: "hidden", // This makes button box-shadow not appear outside of box
@@ -185,6 +198,8 @@ const Top = () => {
           Log
         </Button>
       </Box>
+      }
+      { !disableConcertLogger &&
       <ConcertLogger
         open={logOpen}
         isEditMode={logEditMode}
@@ -192,6 +207,7 @@ const Top = () => {
         setEditMode={setLogEditMode}
         cancelEdit={cancelEdit}
       />
+      }
     </Box> // Container
   );
 };


### PR DESCRIPTION
* Employ useLocation hook from react-router-dom
* Don't render log button, concert logger, and navbar when in the dashboard.
* Adjust size of div to push down body based on whether navbar is disabled