### PR TITLE
include Performance in concertCard and Utils cleanups

### DIFF
--- a/src/components/ConcertCard.tsx
+++ b/src/components/ConcertCard.tsx
@@ -10,7 +10,7 @@ import SvgIcon from "@mui/material/SvgIcon";
 import { useTheme } from "@mui/material/styles";
 import { ReactComponent as BellIcon } from "../assets/bell.svg";
 import { ReactComponent as EditIcon } from "../assets/edit.svg";
-import { Note, Song, Performance, Concert } from "../typing/types";
+import { Note, DBSong, Performance, Concert } from "../typing/types";
 import { Link as MuiLink } from "@mui/material";
 import logger from "../shared/logger";
 
@@ -78,7 +78,6 @@ const ConcertCard = ({ concert, logEdit }: Props) => {
           </Stack>
 
           {/*** Concert Songs List *********************************/}
-          {/* TODO - UNCOMMENT THIS WHEN PERFORMANCES IN DB
           <List dense sx={{ ml: 7, listStyleType: "disc" }}>
             {concert.performances.map(performance => {
               return (
@@ -87,20 +86,19 @@ const ConcertCard = ({ concert, logEdit }: Props) => {
                     display="inline"
                     variant="body2"
                     color="secondary.main"
-                    href={`/song/${performance.song.id}`}
+                    href={`/song/${performance.song._id}`}
                     underline="hover"
                   >
                     {`${performance.song.sheet[0]} - ${performance.song.title}`}
                   </MuiLink>
                   <Typography display="inline" variant="body2">
-                    {` (${performance.performers.join(", ")})`}
+                    {` (${performance.initialsList.join(", ")})`}
                   </Typography>
                 </ListItemText>
               );
             })}
           </List>
-          */}
-        </CardContent>
+=        </CardContent>
       </Card>
     </Box>
   );

--- a/src/components/ConcertCard.tsx
+++ b/src/components/ConcertCard.tsx
@@ -76,7 +76,6 @@ const ConcertCard = ({ concert, logEdit }: Props) => {
               }}
             />
           </Stack>
-
           {/*** Concert Songs List *********************************/}
           <List dense sx={{ ml: 7, listStyleType: "disc" }}>
             {concert.performances.map(performance => {
@@ -98,7 +97,8 @@ const ConcertCard = ({ concert, logEdit }: Props) => {
               );
             })}
           </List>
-=        </CardContent>
+          ={" "}
+        </CardContent>
       </Card>
     </Box>
   );

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -19,9 +19,9 @@ import { Link as RouterLink } from "react-router-dom";
 import {
   resultTableRowData,
   searchByFieldRowData,
-  Song,
+  DBSong,
 } from "../typing/types";
-import { songDisplayFieldToVar } from "../shared/utils";
+import { songFieldToVar } from "../shared/utils";
 import { useState, useEffect } from "react";
 
 import logger from "../shared/logger";
@@ -52,7 +52,7 @@ const playingStatsFieldsFull = [
 ];
 
 function getField(field: string): string {
-  return field == "Song" ? "title" : songDisplayFieldToVar(field);
+  return field == "Song" ? "title" : songFieldToVar(field);
 }
 
 // Example from https://mui.com/material-ui/react-table/

--- a/src/pages/CM.tsx
+++ b/src/pages/CM.tsx
@@ -12,8 +12,8 @@ import ButtonBase from "@mui/material/ButtonBase";
 // Custom Components
 import { ResultsTable } from "../components/ResultsTable";
 import ConcertGrid from "../components/ConcertGrid";
-import { Person, Song, SongDisplay, resultTableRowData } from "../typing/types";
-import { sortConcertsByDate, songListToSongDisplayList } from "../shared/utils";
+import { Person, DBSong, Song, resultTableRowData } from "../typing/types";
+import { sortConcertsByDate, DBSongList2FESongList } from "../shared/utils";
 import logger from "../shared/logger";
 
 const intraPageFields = [
@@ -168,11 +168,11 @@ function CMPageArrangements(props: { initials: string | undefined }) {
     fetch(`/song/search?arranger=${props.initials}`)
       .then(res => res.json())
       .then(data => {
-        // Convert to songDisplay
-        const resAsSongDisplay = songListToSongDisplayList(data);
+        // Convert to Song
+        const resAsSong = DBSongList2FESongList(data);
         // Calculate "you"
         // "you" not implemented yet
-        setData(resAsSongDisplay);
+        setData(resAsSong);
       });
   }, [props.initials]);
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,11 @@ import Typography from "@mui/material/Typography";
 import { Concert } from "../typing/types";
 import CustomDatePicker from "../components/CustomDatePicker";
 
-import { DBSong2FESong, sortConcertsByDate, DBConcertList2FEConcertList } from "../shared/utils";
+import {
+  DBSong2FESong,
+  sortConcertsByDate,
+  DBConcertList2FEConcertList,
+} from "../shared/utils";
 import logger from "../shared/logger";
 
 /*************************************************************

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,7 @@ import Typography from "@mui/material/Typography";
 import { Concert } from "../typing/types";
 import CustomDatePicker from "../components/CustomDatePicker";
 
-import { sortConcertsByDate } from "../shared/utils";
+import { DBSong2FESong, sortConcertsByDate, DBConcertList2FEConcertList } from "../shared/utils";
 import logger from "../shared/logger";
 
 /*************************************************************
@@ -37,10 +37,10 @@ const Home = memo(function Home({ logEdit }: HomePageProps) {
   logger.log(name, `Render`, logger.logLevel.INFO);
 
   const searchStart = "2006-01-01";
-  const tempSearchDate = "2013-05-05";
+  const tempSearchDate = "2006-05-05";
 
   // The concert history itself
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<Concert[]>([]);
 
   // The dates for the search range
   // These should be ISO strings
@@ -78,8 +78,11 @@ const Home = memo(function Home({ logEdit }: HomePageProps) {
 
     fetch(fetchStr)
       .then(res => res.json())
-      .then(data => setData(data));
+      // Convert the songs to Song
+      .then(data => setData(DBConcertList2FEConcertList(data)));
   }, [dateFrom, dateTo]);
+
+  logger.printObj(data, logger.logLevel.DEBUG);
 
   return (
     // TODO: Make a reusable body container

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -9,15 +9,14 @@ import {
 import { useState, useEffect, memo } from "react";
 import dayjs from "dayjs";
 import { Dayjs } from "dayjs";
-
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 // Custom Components
 import { ResultsTable, SearchByFieldResults } from "../components/ResultsTable";
 // Custom Types
-import { Song, SongDisplay, resultTableRowData } from "../typing/types";
-import { songListToSongDisplayList } from "../shared/utils";
+import { DBSong, Song, resultTableRowData } from "../typing/types";
+import { DBSongList2FESongList } from "../shared/utils";
 import logger from "../shared/logger";
 
 /***************************************************************
@@ -50,7 +49,7 @@ const SearchResults = memo(function SearchResults({
    * Using useLocation's search attribute seems to do the trick.
    */
 
-  const [returnedSongs, setReturnedSongs] = useState<SongDisplay[]>([]);
+  const [returnedSongs, setReturnedSongs] = useState<Song[]>([]);
   const numResults = returnedSongs.length;
 
   useEffect(() => {
@@ -61,11 +60,11 @@ const SearchResults = memo(function SearchResults({
         //fetch(`song/search?${searchParams["searchBy"]}=${searchParams["q"]}`)
         .then(res => res.json())
         .then(data => {
-          // Convert to songDisplay
-          const resAsSongDisplay = songListToSongDisplayList(data);
+          // Convert to Song
+          const resAsSong = DBSongList2FESongList(data);
           // Calculate "you"
           // "you" not implemented yet
-          setReturnedSongs(resAsSongDisplay);
+          setReturnedSongs(resAsSong);
         });
     searchDone();
   }, [newSearch]);

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -21,14 +21,14 @@ import { makeStyles } from "@material-ui/styles";
 import { IconButton } from "@mui/material";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { songFieldToDisplay, songToDisplayObj } from "../shared/utils";
+import { songFieldToDisplay, DBSong2FESong } from "../shared/utils";
 import CustomDatePicker from "../components/CustomDatePicker";
 
 import logger from "../shared/logger";
 
 import {
+  DBSong,
   Song,
-  SongDisplay,
   songStats,
   songPageData,
   songHistory,
@@ -39,7 +39,7 @@ import { Dayjs } from "dayjs";
 //https://stackoverflow.com/questions/51419176/how-to-get-a-subset-of-keyof-t-whose-value-tk-are-callable-functions-in-typ
 // Making a type of list fields so checking for length doesn't error out when you remove items
 type KeyOfType<T, U> = { [P in keyof T]: T[P] extends U ? P : never }[keyof T];
-type ListTags = KeyOfType<SongDisplay, string[]>;
+type ListTags = KeyOfType<Song, string[]>;
 
 interface SongTitleProps {
   sheet: string;
@@ -47,7 +47,7 @@ interface SongTitleProps {
 }
 
 interface SongTagProp {
-  tagName: keyof SongDisplay;
+  tagName: keyof Song;
   tagData: string[];
 }
 
@@ -94,7 +94,7 @@ const ListSongTag = ({ tagName, tagData }: SongTagProp) => {
  * Props:
  * ***************************************************************/
 interface SingleSongTagProp {
-  tagName: keyof SongDisplay | string; // temp hack for now
+  tagName: keyof Song | string; // temp hack for now
   tagData: string;
 }
 
@@ -249,7 +249,7 @@ const EditSongTag = ({
  * Props:
  * ***************************************************************/
 interface SongInfoProps {
-  song: SongDisplay;
+  song: Song;
   isEditMode: boolean;
   removeFieldListItem: Function;
   addFieldListItem: Function;
@@ -264,7 +264,7 @@ const SongInfo = ({
   editFieldListItem,
 }: SongInfoProps) => {
   console.log(`Rendering SongInfo in Edit Mode ${isEditMode}`);
-  const tagInfoRow1: (keyof SongDisplay)[] = [
+  const tagInfoRow1: (keyof Song)[] = [
     "sheet",
     "composer",
     "arranger",
@@ -482,10 +482,10 @@ const SongPage = () => {
   const { id } = useParams(); // Get ID of song from URL
 
   /*** State Variables ********************************************/
-  const [data, setData] = useState<SongDisplay>({} as SongDisplay); //<songPageData>({} as songPageData);
+  const [data, setData] = useState<Song>({} as Song); //<songPageData>({} as songPageData);
   const [isEditMode, setEditMode] = useState(false);
   const [ready, setReady] = useState(false); // This prevents trying to access empty data before fetching is done.
-  const [songForm, setSongForm] = useState<SongDisplay>(new SongDisplay());
+  const [songForm, setSongForm] = useState<Song>(new Song());
 
   //const { song, stats, playsPerCM, history } = data;
   const song = data;
@@ -548,7 +548,7 @@ const SongPage = () => {
     fetch(`/song/${id}`)
       .then(res => res.json())
       .then(dataIn => {
-        const temp = songToDisplayObj(dataIn);
+        const temp = DBSong2FESong(dataIn);
         setData(temp);
         setSongForm(JSON.parse(JSON.stringify(temp))); // Needs a "Deep Copy"
       })

--- a/src/shared/utils.tsx
+++ b/src/shared/utils.tsx
@@ -3,7 +3,70 @@ Some utility functions that can be reused
 */
 import dayjs from "dayjs";
 import { Dayjs } from "dayjs";
-import { Song, SongDisplay, Concert } from "../typing/types";
+import { DBSong, Song, DBConcert, Concert, DBPerformance, Performance, PerformanceFields } from "../typing/types";
+
+/********************************
+ * Date Processing
+ ********************************/
+
+// Use this to convert hash key to date display - SUPER JANKY MAKE IT BETTER
+export function dateHashToDisplayStr(dateHash: number): string {
+  const dateStr = dateHash.toString();
+  const year = dateStr.substring(0, 4);
+  const month = dateStr.substring(4, 6); // month is already adjusted to 1-indexed value
+  const day = dateStr.substring(6);
+  const dateObj = dayjs(`${year}-${month}-${day}`, "YYYY-MM-DD", true);
+  return dateObj.format("MMMM D, YYYY");
+}
+
+// Use this for sorting/indexing concert data by dates
+export function dateToHash(date: Date): number {
+  return (
+    date.getFullYear() * 10000 +
+    (date.getMonth() + 1) * 100 + // plus 1 because months index from 0
+    date.getDate()
+  );
+}
+
+/********************************
+ * Song Processing
+ ********************************/
+
+// Function that separates delimited tags and returns them in a list
+function splitDelimitedTag(data: string) {
+  return data.split("|");
+}
+
+// Helper function that converts date string to a display-friendly string
+function dateToDisplaySlash(date: string) {
+  const asDate = dayjs(date);
+  return asDate.format("M/D/YYYY");
+}
+
+// Filter out the unneeded fields in DB entity and convert delimited fields to list
+// Changing attribute names so they can work in songFieldToDisplay
+export function DBSong2FESong(dbSong: DBSong) {
+  const feSong: Song = {
+    _id: dbSong.id,
+    sheet: splitDelimitedTag(dbSong.location),
+    title: dbSong.title,
+    composer: splitDelimitedTag(dbSong.composer),
+    arranger: splitDelimitedTag(dbSong.arranger),
+    genre: splitDelimitedTag(dbSong.genre),
+    key: splitDelimitedTag(dbSong.keySignature),
+    time_sig: splitDelimitedTag(dbSong.timeSignature),
+    tempo: splitDelimitedTag(dbSong.tempo),
+    date_added: dateToDisplaySlash(dbSong.dateAdded),
+  };
+  return feSong;
+}
+
+export function DBSongList2FESongList(dbSongList: DBSong[]) {
+  let feSongList: Song[] = dbSongList.map((song: DBSong) => {
+    return DBSong2FESong(song);
+  });
+  return feSongList;
+}
 
 // Convert song tag attribute name to what is shown on screen
 export function songFieldToDisplay(field: string) {
@@ -29,66 +92,51 @@ export function songFieldToDisplay(field: string) {
 }
 
 // Convert on-screen tag attribute name to variable name
-export function songDisplayFieldToVar(field: string) {
+export function songFieldToVar(field: string) {
   if (!field) {
     return "";
   }
   return field.toLowerCase().replaceAll(" ", "_");
 }
 
-// Function that separates delimited tags and returns them in a list
-export function splitDelimitedTag(data: string) {
-  return data.split("|");
+/********************************
+ * Performance Processing
+ ********************************/
+
+export function DBPerf2FEPerf(dbPerf: DBPerformance) {
+  const fePerfParams: PerformanceFields = {
+    ...dbPerf,
+    performers: dbPerf.performers.map((p) => { return p.performer}),
+    song: DBSong2FESong(dbPerf.song)
+  }
+  const fePerf: Performance = new Performance(fePerfParams);
+  return fePerf;
 }
 
-// Helper function that converts date string to a display-friendly string
-function dateToDisplaySlash(date: string) {
-  const asDate = dayjs(date);
-  return asDate.format("M/D/YYYY");
+export function DBPerfList2FEPerfList(dbPerfList: DBPerformance[]) {
+  const fePerfList: Performance[] = dbPerfList.map((dbPerf: DBPerformance) => {
+    return DBPerf2FEPerf(dbPerf);
+  })
+  return fePerfList;
 }
 
-// Filter out the unneeded fields in DB entity and convert delimited fields to list
-// Changing attribute names so they can work in songFieldToDisplay
-export function songToDisplayObj(song: Song) {
-  const displaySong: SongDisplay = {
-    _id: song.id,
-    sheet: splitDelimitedTag(song.location),
-    title: song.title,
-    composer: splitDelimitedTag(song.composer),
-    arranger: splitDelimitedTag(song.arranger),
-    genre: splitDelimitedTag(song.genre),
-    key: splitDelimitedTag(song.keySignature),
-    time_sig: splitDelimitedTag(song.timeSignature),
-    tempo: splitDelimitedTag(song.tempo),
-    date_added: dateToDisplaySlash(song.dateAdded),
-  };
-  return displaySong;
+/********************************
+ * Concert Processing
+ ********************************/
+
+export function DBConcert2FEConcert(dbConcert: DBConcert) {
+  const feConcert: Concert = {
+    ...dbConcert,
+    performances: DBPerfList2FEPerfList(dbConcert.performances)
+  }
+  return feConcert;
 }
 
-export function songListToSongDisplayList(songList: Song[]) {
-  let songDisplayList: SongDisplay[] = songList.map((song: Song) => {
-    return songToDisplayObj(song);
-  });
-  return songDisplayList;
-}
-
-// Use this to convert hash key to date display - SUPER JANKY MAKE IT BETTER
-export function dateHashToDisplayStr(dateHash: number): string {
-  const dateStr = dateHash.toString();
-  const year = dateStr.substring(0, 4);
-  const month = dateStr.substring(4, 6); // month is already adjusted to 1-indexed value
-  const day = dateStr.substring(6);
-  const dateObj = dayjs(`${year}-${month}-${day}`, "YYYY-MM-DD", true);
-  return dateObj.format("MMMM D, YYYY");
-}
-
-// Use this for sorting/indexing concert data by dates
-export function dateToHash(date: Date): number {
-  return (
-    date.getFullYear() * 10000 +
-    (date.getMonth() + 1) * 100 + // plus 1 because months index from 0
-    date.getDate()
-  );
+export function DBConcertList2FEConcertList(dbConcertList: DBConcert[]) {
+  const feConcertList: Concert[] = dbConcertList.map((dbConcert: DBConcert) => {
+    return DBConcert2FEConcert(dbConcert);
+  })
+  return feConcertList;
 }
 
 export function sortConcertsByDate(concerts: Concert[]) {
@@ -103,3 +151,5 @@ export function sortConcertsByDate(concerts: Concert[]) {
   });
   return concertsByDate;
 }
+
+

--- a/src/shared/utils.tsx
+++ b/src/shared/utils.tsx
@@ -3,7 +3,15 @@ Some utility functions that can be reused
 */
 import dayjs from "dayjs";
 import { Dayjs } from "dayjs";
-import { DBSong, Song, DBConcert, Concert, DBPerformance, Performance, PerformanceFields } from "../typing/types";
+import {
+  DBSong,
+  Song,
+  DBConcert,
+  Concert,
+  DBPerformance,
+  Performance,
+  PerformanceFields,
+} from "../typing/types";
 
 /********************************
  * Date Processing
@@ -106,9 +114,11 @@ export function songFieldToVar(field: string) {
 export function DBPerf2FEPerf(dbPerf: DBPerformance) {
   const fePerfParams: PerformanceFields = {
     ...dbPerf,
-    performers: dbPerf.performers.map((p) => { return p.performer}),
-    song: DBSong2FESong(dbPerf.song)
-  }
+    performers: dbPerf.performers.map(p => {
+      return p.performer;
+    }),
+    song: DBSong2FESong(dbPerf.song),
+  };
   const fePerf: Performance = new Performance(fePerfParams);
   return fePerf;
 }
@@ -116,7 +126,7 @@ export function DBPerf2FEPerf(dbPerf: DBPerformance) {
 export function DBPerfList2FEPerfList(dbPerfList: DBPerformance[]) {
   const fePerfList: Performance[] = dbPerfList.map((dbPerf: DBPerformance) => {
     return DBPerf2FEPerf(dbPerf);
-  })
+  });
   return fePerfList;
 }
 
@@ -127,15 +137,15 @@ export function DBPerfList2FEPerfList(dbPerfList: DBPerformance[]) {
 export function DBConcert2FEConcert(dbConcert: DBConcert) {
   const feConcert: Concert = {
     ...dbConcert,
-    performances: DBPerfList2FEPerfList(dbConcert.performances)
-  }
+    performances: DBPerfList2FEPerfList(dbConcert.performances),
+  };
   return feConcert;
 }
 
 export function DBConcertList2FEConcertList(dbConcertList: DBConcert[]) {
   const feConcertList: Concert[] = dbConcertList.map((dbConcert: DBConcert) => {
     return DBConcert2FEConcert(dbConcert);
-  })
+  });
   return feConcertList;
 }
 
@@ -151,5 +161,3 @@ export function sortConcertsByDate(concerts: Concert[]) {
   });
   return concertsByDate;
 }
-
-

--- a/src/typing/types.tsx
+++ b/src/typing/types.tsx
@@ -96,9 +96,9 @@ export class Performance {
   }
 
   get initialsList() {
-    return this.performers.map((person) => {
+    return this.performers.map(person => {
       return person.initials;
-    })
+    });
   }
 }
 

--- a/src/typing/types.tsx
+++ b/src/typing/types.tsx
@@ -13,47 +13,22 @@ export class Note {
   text: string = "";
 }
 
-export class Song {
+export interface DBSong {
   id: number;
-  location: string = "";
-  title: string = "";
-  composer: string = "";
-  arranger: string = "";
-  genre: string = "";
-  requests: number = 0;
-  keySignature: string = "";
-  timeSignature: string = "";
-  tempo: string = "";
-  dateAdded: string = "";
-  constructor(
-    id: number = 0,
-    sheet: string = "",
-    title: string = "",
-    composer: string = "",
-    arranger: string = "",
-    genre: string = "",
-    requests: number = 0,
-    keySignature: string = "",
-    timeSignature: string = "",
-    tempo: string = "",
-    dateAdded: string = ""
-  ) {
-    this.id = id;
-    this.location = sheet;
-    this.title = title;
-    this.composer = composer;
-    this.arranger = arranger;
-    this.genre = genre;
-    this.requests = requests;
-    this.keySignature = keySignature;
-    this.timeSignature = timeSignature;
-    this.tempo = tempo;
-    this.dateAdded = dateAdded;
-  }
+  location: string;
+  title: string;
+  composer: string;
+  arranger: string;
+  genre: string;
+  requests: number;
+  keySignature: string;
+  timeSignature: string;
+  tempo: string;
+  dateAdded: string;
 }
 
 // Non backend
-export class SongDisplay {
+export class Song {
   _id: number;
   sheet: string[] = [""];
   title: string = "";
@@ -89,11 +64,51 @@ export class SongDisplay {
   }
 }
 
+export interface DBPerfMap {
+  _id: number;
+  performanceId: number;
+  performerId: number;
+  performer: Person;
+}
+
+export interface DBPerformance {
+  _id: number;
+  song: DBSong;
+  performers: DBPerfMap[];
+  isRequest?: boolean;
+}
+
+export interface PerformanceFields {
+  _id: number;
+  song: Song;
+  performers: Person[];
+  isRequest?: boolean;
+}
+
 export class Performance {
   _id: number = 0;
   song: Song = new Song();
-  isRequest: boolean = false;
-  performers: String[] = [];
+  performers: Person[] = [];
+  isRequest?: boolean = false;
+
+  constructor(opts: PerformanceFields) {
+    Object.assign(this, opts);
+  }
+
+  get initialsList() {
+    return this.performers.map((person) => {
+      return person.initials;
+    })
+  }
+}
+
+export interface DBConcert {
+  id: number;
+  type: string;
+  date: Date;
+  bellsAdjusted: boolean;
+  notes: string;
+  performances: DBPerformance[];
 }
 
 export class Concert {
@@ -129,6 +144,7 @@ export class Person {
   location: string = "";
   activeYears: string = "";
   isCurrent: boolean = false;
+
   constructor(opts: PersonFields) {
     Object.assign(this, opts);
   }
@@ -141,7 +157,7 @@ export class Person {
 //----------------------------------------
 // Results Table
 //----------------------------------------
-export interface resultTableRowData extends SongDisplay {
+export interface resultTableRowData extends Song {
   available?: Dayjs; //  TODO MAKE THIS REQUIRED WHEN ITS ENABLED
   you?: number;
 }
@@ -189,7 +205,7 @@ export interface songHistory {
 }
 
 export interface songPageData {
-  song: Song;
+  song: DBSong;
   stats: songStats;
   playsPerCM: playsPerCM;
   history: songHistory;


### PR DESCRIPTION
Concert cards now grab performances from DB.
Utils cleanups
  - Better code style
  - Consistent naming convention of functions
  - Consistent naming convention of DB vs Frontend Classes
  - - DB* for DB structures (e.g. DBSong)
  - - Just entity name for Frontend stuctures (e.g. Song)